### PR TITLE
Fix installer sample content creation error

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -143,8 +143,7 @@ class Events
 
         $comment = new \humhub\modules\comment\models\Comment();
         $comment->message = Yii::t('PollsModule.base', "Why don't we go to Bemelmans Bar?");
-        $comment->object_model = $poll->className();
-        $comment->object_id = $poll->getPrimaryKey();
+        $comment->content_id = $poll->content->id;
         $comment->save();
 
         // Switch Identity
@@ -155,8 +154,7 @@ class Events
 
         $comment = new \humhub\modules\comment\models\Comment();
         $comment->message = Yii::t('PollsModule.base', "Again? :weary:");
-        $comment->object_model = $poll->className();
-        $comment->object_id = $poll->getPrimaryKey();
+        $comment->content_id = $poll->content->id;
         $comment->save();
 
         // Switch Identity

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.5.1 (Unreleased)
+------------------
+- Fix #175: Error creating installer sample content (comment no longer uses removed `object_model`/`object_id` properties)
+
 1.5.0 (June 5, 2026)
 --------------------
 - Enh #174: Update for HumHub 1.19


### PR DESCRIPTION
Fixes Issue humhub/humhub-internal#1221

`Events::onSampleDataInstall()` attaches sample comments via the removed polymorphic `object_model`/`object_id` properties, which now throws `UnknownPropertyException` on a clean install from `humhub:develop` (v1.19) with sample content enabled. Content addons now attach via `content_id` (as core's own installer already does).